### PR TITLE
Allow StreamConnector to pass large messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Elchinchel/communica/issues/1
-Your prepared branch: issue-1-1c35078b
-Your prepared working directory: /tmp/gh-issue-solver-1760065947840
-Your forked repository: konard/communica
-Original repository (upstream): Elchinchel/communica
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/Elchinchel/communica/issues/1
+Your prepared branch: issue-1-1c35078b
+Your prepared working directory: /tmp/gh-issue-solver-1760065947840
+Your forked repository: konard/communica
+Original repository (upstream): Elchinchel/communica
+
+Proceed.

--- a/experiments/test_large_message.py
+++ b/experiments/test_large_message.py
@@ -1,0 +1,91 @@
+"""
+Experiment script to validate large message chunking functionality.
+
+This script demonstrates that the StreamConnector can now handle messages
+larger than _MAX_CHUNK_SIZE by automatically splitting them into chunks
+and reassembling them on the receiving end.
+"""
+import asyncio
+import sys
+import os
+
+# Add parent directory to path to import communica
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from communica import SimpleServer, SimpleClient, TcpConnector
+from communica.serializers import JsonSerializer
+
+
+async def main():
+    connector = TcpConnector('localhost', 16162)
+    serializer = JsonSerializer()
+
+    print('Testing large message chunking...\n')
+
+    # Test 1: Send a 10MB message
+    print('Test 1: Sending 10MB message')
+    large_data = b'x' * (10 * 1024 * 1024)
+    print(f'  Data size: {len(large_data):,} bytes')
+
+    received_data = []
+
+    def handler(data):
+        print(f'  Server received: {len(data):,} bytes')
+        received_data.append(data)
+        return f'Received {len(data)} bytes'
+
+    server = SimpleServer(connector, handler, serializer)
+    await server.init()
+
+    try:
+        async with SimpleClient(connector, serializer) as client:
+            response = await client.request(large_data)
+            print(f'  Client received response: {response}')
+
+        assert len(received_data) == 1
+        assert received_data[0] == large_data
+        print('  ✓ Test 1 passed: Data transmitted correctly\n')
+
+        # Test 2: Send multiple large messages
+        print('Test 2: Sending multiple large messages (5MB, 7MB, 3MB)')
+        received_data.clear()
+
+        data_1 = b'a' * (5 * 1024 * 1024)
+        data_2 = b'b' * (7 * 1024 * 1024)
+        data_3 = b'c' * (3 * 1024 * 1024)
+
+        async with SimpleClient(connector, serializer) as client:
+            resp1 = await client.request(data_1)
+            print(f'  Response 1: {resp1}')
+            resp2 = await client.request(data_2)
+            print(f'  Response 2: {resp2}')
+            resp3 = await client.request(data_3)
+            print(f'  Response 3: {resp3}')
+
+        assert len(received_data) == 3
+        assert received_data[0] == data_1
+        assert received_data[1] == data_2
+        assert received_data[2] == data_3
+        print('  ✓ Test 2 passed: Multiple messages transmitted correctly\n')
+
+        # Test 3: Send a very small message to verify normal path still works
+        print('Test 3: Sending small message (1KB)')
+        received_data.clear()
+
+        small_data = b'small' * 200  # 1KB
+
+        async with SimpleClient(connector, serializer) as client:
+            response = await client.request(small_data)
+            print(f'  Response: {response}')
+
+        assert len(received_data) == 1
+        assert received_data[0] == small_data
+        print('  ✓ Test 3 passed: Small messages still work correctly\n')
+
+        print('All tests passed! ✓')
+    finally:
+        await server.close()
+
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Implements message chunking for large messages that exceed `_MAX_CHUNK_SIZE` in StreamConnector, as requested in issue #1.

## Implementation Details

### Core Changes
- **ChunkedMessageFrame**: New frame type (CODE=11) for chunked messages
  - Header contains: `chunk_index`, `total_chunks`, `metadata_length` (3 x uint32)
  - Metadata included only in first chunk to reduce bandwidth
  - `metadata_length` is 0 for non-first chunks
  
- **Atomic chunk transmission**: 
  - `await put()` for first chunk to wait for queue space
  - `put_nowait()` for remaining chunks to guarantee all chunks are queued together
  - Ensures no interleaving with other messages

- **Message reassembly**:
  - Uses list instead of dict for chunk storage (order guaranteed by connection)
  - Deserializes metadata from bytes before passing to callback
  - Incomplete messages discarded on connection loss

### Testing
- Tests now actually test chunking by temporarily reducing `_MAX_CHUNK_SIZE` to 1MB
- Uses context managers for cleaner test code
- Tests verify:
  - Large message transmission (10MB)
  - Multiple sequential large messages
  - Small messages still work correctly
  - Boundary conditions

### Changes from Code Review

All review feedback addressed:
- ✅ Include `metadata_length` in chunk header (no separate field needed)
- ✅ Use list instead of dict for chunk storage
- ✅ Remove impossible condition check (order guaranteed)
- ✅ Remove single-chunk message check (wouldn't be ChunkedMessageFrame)
- ✅ Use memoryview directly without casting to bytes
- ✅ Deserialize metadata before passing to callback
- ✅ Create reusable context managers for tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)